### PR TITLE
Dont fetch any metrics for chart in MGMT

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -19,8 +19,6 @@ func Version(w http.ResponseWriter, r *http.Request) {
 
 func Router() *goji.Mux {
 	mux := goji.SubMux()
-	mux.Use(m.RequestId)
-	mux.Use(m.Logger)
 	mux.Use(m.HostnameToResponse)
 	mux.Use(m.SecureApi)
 

--- a/static/broker.html
+++ b/static/broker.html
@@ -26,7 +26,6 @@
           <tr>
             <td id="leader_count"></td>
             <td id="partition_count"></td>
-            <td id="size"></td>
             <td id="uptime"></td>
           </tr>
         </tbody>
@@ -34,19 +33,10 @@
           <tr>
             <th class="cols-3">Leader</th>
             <th class="cols-3">Partitions</th>
-            <th class="cols-3">size</th>
             <th class="cols-3">Uptime</th>
           </tr>
         </tfoot>
       </table>
-      <section class="card cols-6">
-        <h3>Data rates</h3>
-        <div class="chart-container" id="dataChart"></div>
-      </section>
-      <section class="card cols-12 cols-6-md">
-        <h3>ISR</h3>
-        <div class="chart-container" id="isrChart"></div>
-      </section>
     </main>
     <footer></footer>
     <script src="/js/layout.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -24,8 +24,6 @@
             <td class="brokers"></td>
             <td class="topics"></td>
             <td class="partitions"></td>
-            <td class="topic_size"></td>
-            <td class="messages"></td>
             <td class="consumers"></td>
             <td class="uptime"></td>
           </tr>
@@ -35,21 +33,11 @@
             <th><a href="/brokers">Brokers</a></th>
             <th><a href="/topics">Topics</a></th>
             <th>Partitions</th>
-            <th>Topic size</th>
-            <th>Messages</th>
             <th><a href="/consumers">Consumers</a></th>
             <th>Uptime</th>
           </tr>
         </tfoot>
       </table>
-      <section class="card cols-6 cols-6-md">
-        <h3>Data rates</h3>
-        <div class="chart-container" id="dataChart"></div>
-      </section>
-      <section class="card cols-6 cols-6-md">
-        <h3>ISR</h3>
-        <div class="chart-container" id="isrChart"></div>
-      </section>
     </main>
     <footer></footer>
     <script src="/js/layout.js"></script>
@@ -59,8 +47,6 @@
     <script src="/js/helpers.js"></script>
     <script src="/js/overview.js"></script>
     <script src="/js/table.js"></script>
-    <script src="/js/lib/chart.js"></script>
-    <script src="/js/chart.js"></script>
     <script src="/js/index.js"></script>
   </body>
 </html>

--- a/static/js/broker.js
+++ b/static/js/broker.js
@@ -49,7 +49,7 @@
     if (table) {
       table.querySelector('#leader_count').innerText = data.leader
       table.querySelector('#partition_count').innerText = data.partitions
-      table.querySelector('#size').innerText = data.topic_size
+      //table.querySelector('#size').innerText = data.topic_size
       table.querySelector('#uptime').innerText = data.uptime
     }
   }
@@ -88,19 +88,7 @@
     }
   })
 
-  const dataChart = ckm.chart.render('dataChart', 'bytes/s', { aspectRatio: 2 })
-  const isrChart = ckm.chart.render('isrChart', 'changes/s', { aspectRatio: 2 })
   function updateView (response) {
-    let dataStats = {
-      send_details: response.bytes_out,
-      receive_details: response.bytes_in
-    }
-    ckm.chart.update(dataChart, dataStats)
-    let isrStats = {
-      isr_shrink: response.isr_shrink,
-      isr_expand: response.isr_expand,
-    }
-    ckm.chart.update(isrChart, isrStats)
   }
 
   ckm.broker.start(updateView)

--- a/static/js/broker.js
+++ b/static/js/broker.js
@@ -49,7 +49,6 @@
     if (table) {
       table.querySelector('#leader_count').innerText = data.leader
       table.querySelector('#partition_count').innerText = data.partitions
-      //table.querySelector('#size').innerText = data.topic_size
       table.querySelector('#uptime').innerText = data.uptime
     }
   }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,18 +1,5 @@
 (function() {
-    const dataChart = ckm.chart.render('dataChart', 'bytes/s', { aspectRatio: 2 })
-    const isrChart = ckm.chart.render('isrChart', 'changes/s', { aspectRatio: 2 })
-
     function updateCharts (response) {
-      let dataStats = {
-        send_details: response.bytes_out,
-        receive_details: response.bytes_in
-      }
-      ckm.chart.update(dataChart, dataStats)
-      let isrStats = {
-        isr_shrink: response.isr_shrink,
-        isr_expand: response.isr_expand,
-      }
-      ckm.chart.update(isrChart, isrStats)
     }
 
     ckm.overview.start(updateCharts)

--- a/static/js/overview.js
+++ b/static/js/overview.js
@@ -53,8 +53,6 @@
       table.querySelector('.brokers').innerText = data.brokers
       table.querySelector('.topics').innerText = data.topics
       table.querySelector('.partitions').innerText = data.partitions
-      table.querySelector('.topic_size').innerText = ckm.helpers.formatNumber(data.topic_size)
-      table.querySelector('.messages').innerText = ckm.helpers.formatNumber(data.messages)
       table.querySelector('.consumers').innerText = data.consumers
       table.querySelector('.uptime').innerText = data.uptime
     }

--- a/static/js/topic.js
+++ b/static/js/topic.js
@@ -98,7 +98,6 @@
     update, start, stop, render, get, url, name
   })
 
-  const dataChart = ckm.chart.render('dataChart', 'bytes/s', { aspectRatio: 2 })
   const tableOptions = {
     url: `${ckm.topic.url}/partitions`,
     interval: 5000,
@@ -113,18 +112,9 @@
     ckm.table.renderCell(tr, 1, p.leader, 'center')
     ckm.table.renderCell(tr, 2, p.isr, 'center')
     ckm.table.renderCell(tr, 3, p.replicas, 'center')
-    ckm.table.renderCell(tr, 4, p.metrics["LogStartOffset"], 'center')
-    ckm.table.renderCell(tr, 5, p.metrics["LogEndOffset"], 'center')
-    ckm.table.renderCell(tr, 6, p.metrics["Size"], 'center')
   })
 
   function updateView (response) {
-    let dataStats = {
-      send_details: response.bytes_out,
-      receive_details: response.bytes_in
-    }
-    ckm.chart.update(dataChart, dataStats)
-
     var tBody = document.querySelector('#config tbody')
     ckm.dom.removeChildren(tBody);
     if (response.config !== undefined) {

--- a/static/js/topics.js
+++ b/static/js/topics.js
@@ -13,26 +13,12 @@
       queueLink.textContent = item.name
       ckm.table.renderCell(tr, 0, queueLink)
     }
-
     ckm.table.renderCell(tr, 1, ckm.helpers.formatNumber(item.partitions), 'right')
-
     var tags = document.createElement('div')
-    if (item.message_count !== undefined) {
-      ckm.table.renderCell(tr, 2, ckm.helpers.formatNumber(item.message_count || 0), 'right')
-    } else {
-      ckm.table.renderCell(tr, 2, '-', 'right')
-      tags.appendChild(ckm.dom.createBadge('msg', 'Unable to fetch metrics for message count .', 'primary'))
-    }
-    if (item.size !== undefined) {
-      ckm.table.renderCell(tr, 3, ckm.helpers.formatNumber(item.size || 0), 'right')
-    } else {
-      ckm.table.renderCell(tr, 3, '-', 'right')
-      tags.appendChild(ckm.dom.createBadge('size', 'Unable to fetch metrics for topic size .', 'primary'))
-    }
     if (item.config !== undefined) {
       tags.appendChild(ckm.dom.createBadge('C', 'This topic has custom configuration.', 'primary'))
     }
-    ckm.table.renderCell(tr, 4, tags)
+    ckm.table.renderCell(tr, 2, tags)
   })
   const form = ckm.topic.form('POST', {}, topicsTable.fetchAndUpdate)
   document.getElementsByTagName('main')[0].insertAdjacentElement('beforeend', form)

--- a/static/topic.html
+++ b/static/topic.html
@@ -21,25 +21,23 @@
     </header>
     <aside></aside>
     <main>
-      <table id="topic" class="stats-table card">
-        <tbody>
-          <tr>
-            <td id="t-partitions"></td>
-            <td id="t-size"></td>
-            <td id="t-messages"></td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <th class="cols-4">Partitions</th>
-            <th class="cols-4">Size</th>
-            <th class="cols-4">Messages</th>
-          </tr>
-        </tfoot>
-      </table>
       <section class="card cols-6">
-        <h3>Data rates</h3>
-        <div class="chart-container" id="dataChart"></div>
+        <h3>
+          Partitions
+          <small id="partitions-count"></small>
+        </h3>
+        <div id="partitions-error"></div>
+        <table class="table" id="partitions">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Leader</th>
+                <th>ISR</th>
+                <th>Replicas</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
       </section>
       <section class="card cols-6">
         <h3>Config</h3>
@@ -55,27 +53,6 @@
                 <td colspan=2>No custom configuration</td>
               </tr>
             </tbody>
-        </table>
-      </section>
-      <section class="card cols-12">
-        <h3>
-          Partitions
-          <small id="partitions-count"></small>
-        </h3>
-        <div id="partitions-error"></div>
-        <table class="table" id="partitions">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Leader</th>
-                <th>ISR</th>
-                <th>Replicas</th>
-                <th>Log Start Offset</th>
-                <th>Log End Offset</th>
-                <th>Size</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
         </table>
       </section>
       <section class="card cols-12">

--- a/static/topics.html
+++ b/static/topics.html
@@ -29,8 +29,6 @@
               <tr>
                 <th>Name</th>
                 <th>Partitions</th>
-                <th>Messages</th>
-                <th>Size</th>
                 <th>Tags</th>
               </tr>
             </thead>

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ func FetchMetrics(ctx context.Context, metrics chan Metric, reqs []MetricRequest
 			log.Error("fetch_metrics", log.ErrorEntry{ctx.Err()})
 			break
 		default:
+			fmt.Println("metrics req", r)
 			resp, err := GetMetrics(ctx, r)
 			if err != nil {
 				log.Error("fetch_metrics", log.ErrorEntry{err})
@@ -67,8 +69,8 @@ func handleTopicChanges(topics []zookeeper.T) []MetricRequest {
 					MetricRequest{p.Leader, BeanTopicLogSize(t.Name), "Value"},
 					MetricRequest{p.Leader, BeanTopicLogEnd(t.Name), "Value"},
 					MetricRequest{p.Leader, BeanTopicLogStart(t.Name), "Value"},
-					MetricRequest{p.Leader, BeanTopicBytesOutPerSec(t.Name), "Count"},
-					MetricRequest{p.Leader, BeanTopicBytesInPerSec(t.Name), "Count"},
+					// MetricRequest{p.Leader, BeanTopicBytesOutPerSec(t.Name), "Count"},
+					// MetricRequest{p.Leader, BeanTopicBytesInPerSec(t.Name), "Count"},
 				}...)
 			}
 		}
@@ -78,10 +80,10 @@ func handleTopicChanges(topics []zookeeper.T) []MetricRequest {
 
 func Start() {
 	var (
-		brokerRequests []MetricRequest
-		topicRequests  []MetricRequest
-		ctx            context.Context
-		cancel         context.CancelFunc
+		// brokerRequests []MetricRequest
+		// topicRequests  []MetricRequest
+		ctx    context.Context
+		cancel context.CancelFunc
 
 		topicChanges  = make(chan []zookeeper.T)
 		brokerChanges = make(chan []zookeeper.HostPort)
@@ -106,13 +108,13 @@ func Start() {
 				cancel()
 			}
 			ctx, cancel = context.WithCancel(context.Background())
-			go FetchMetrics(ctx, bMetrics, brokerRequests)
-			go FetchMetrics(ctx, tMetrics, topicRequests)
+			// go FetchMetrics(ctx, bMetrics, brokerRequests)
+			// go FetchMetrics(ctx, tMetrics, topicRequests)
 			go FetchConsumerGroups(ctx, cMetrics)
 		case hps := <-brokerChanges:
-			brokerRequests = handleBrokerChanges(hps)
+			handleBrokerChanges(hps)
 		case topics := <-topicChanges:
-			topicRequests = handleTopicChanges(topics)
+			handleTopicChanges(topics)
 		case metric := <-bMetrics:
 			store.UpdateBrokerMetrics(metric)
 		case metric := <-tMetrics:


### PR DESCRIPTION
Stop the background fetching of all metrics and remove all charts from UI

Currently the manager generates way to many requests (over HTTP) which puts to much load on the brokers. This is a solution until we have found a better alternative. 