### PR TITLE
Fewer metrics

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -19,8 +19,6 @@ func Version(w http.ResponseWriter, r *http.Request) {
 
 func Router() *goji.Mux {
 	mux := goji.SubMux()
-	mux.Use(m.RequestId)
-	mux.Use(m.Logger)
 	mux.Use(m.HostnameToResponse)
 	mux.Use(m.SecureApi)
 

--- a/static/index.html
+++ b/static/index.html
@@ -42,13 +42,9 @@
           </tr>
         </tfoot>
       </table>
-      <section class="card cols-6 cols-6-md">
+      <section class="card cols-12 cols-12-md">
         <h3>Data rates</h3>
         <div class="chart-container" id="dataChart"></div>
-      </section>
-      <section class="card cols-6 cols-6-md">
-        <h3>ISR</h3>
-        <div class="chart-container" id="isrChart"></div>
       </section>
     </main>
     <footer></footer>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,6 +1,5 @@
 (function() {
     const dataChart = ckm.chart.render('dataChart', 'bytes/s', { aspectRatio: 2 })
-    const isrChart = ckm.chart.render('isrChart', 'changes/s', { aspectRatio: 2 })
 
     function updateCharts (response) {
       let dataStats = {
@@ -8,11 +7,6 @@
         receive_details: response.bytes_in
       }
       ckm.chart.update(dataChart, dataStats)
-      let isrStats = {
-        isr_shrink: response.isr_shrink,
-        isr_expand: response.isr_expand,
-      }
-      ckm.chart.update(isrChart, isrStats)
     }
 
     ckm.overview.start(updateCharts)

--- a/static/js/topic.js
+++ b/static/js/topic.js
@@ -98,7 +98,6 @@
     update, start, stop, render, get, url, name
   })
 
-  const dataChart = ckm.chart.render('dataChart', 'bytes/s', { aspectRatio: 2 })
   const tableOptions = {
     url: `${ckm.topic.url}/partitions`,
     interval: 5000,
@@ -123,7 +122,6 @@
       send_details: response.bytes_out,
       receive_details: response.bytes_in
     }
-    ckm.chart.update(dataChart, dataStats)
 
     var tBody = document.querySelector('#config tbody')
     ckm.dom.removeChildren(tBody);

--- a/static/topic.html
+++ b/static/topic.html
@@ -38,26 +38,6 @@
         </tfoot>
       </table>
       <section class="card cols-6">
-        <h3>Data rates</h3>
-        <div class="chart-container" id="dataChart"></div>
-      </section>
-      <section class="card cols-6">
-        <h3>Config</h3>
-        <table class="table" id="config">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th class="left" >Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td colspan=2>No custom configuration</td>
-              </tr>
-            </tbody>
-        </table>
-      </section>
-      <section class="card cols-12">
         <h3>
           Partitions
           <small id="partitions-count"></small>
@@ -76,6 +56,22 @@
               </tr>
             </thead>
             <tbody></tbody>
+        </table>
+      </section>
+      <section class="card cols-6">
+        <h3>Config</h3>
+        <table class="table" id="config">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th class="left" >Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td colspan=2>No custom configuration</td>
+              </tr>
+            </tbody>
         </table>
       </section>
       <section class="card cols-12">

--- a/store/store.go
+++ b/store/store.go
@@ -14,7 +14,7 @@ import (
 const (
 	MaxPoints  int           = 500
 	Timeout    time.Duration = 5 * time.Second
-	SampleTime time.Duration = 10 * time.Second
+	SampleTime time.Duration = 30 * time.Second
 )
 
 func FetchMetrics(ctx context.Context, metrics chan Metric, reqs []MetricRequest) {
@@ -44,8 +44,6 @@ func handleBrokerChanges(hps []zookeeper.HostPort) []MetricRequest {
 		copy(reqs[i*4:], []MetricRequest{
 			MetricRequest{hp.Id, BeanBrokerBytesInPerSec, "Count"},
 			MetricRequest{hp.Id, BeanBrokerBytesOutPerSec, "Count"},
-			MetricRequest{hp.Id, BeanBrokerIsrExpands, "Count"},
-			MetricRequest{hp.Id, BeanBrokerIsrShrinks, "Count"},
 		})
 		broker, _ := fetchBroker(hp.Id)
 		store.UpdateBroker(broker)
@@ -58,7 +56,7 @@ func handleTopicChanges(topics []zookeeper.T) []MetricRequest {
 	for _, t := range topics {
 		topic, _ := FetchTopic(t.Name)
 		store.UpdateTopic(topic)
-		if 200 < len(topic.Partitions) {
+		if 50 < len(topic.Partitions) {
 			continue
 		}
 		for _, p := range topic.Partitions {
@@ -67,8 +65,6 @@ func handleTopicChanges(topics []zookeeper.T) []MetricRequest {
 					MetricRequest{p.Leader, BeanTopicLogSize(t.Name), "Value"},
 					MetricRequest{p.Leader, BeanTopicLogEnd(t.Name), "Value"},
 					MetricRequest{p.Leader, BeanTopicLogStart(t.Name), "Value"},
-					MetricRequest{p.Leader, BeanTopicBytesOutPerSec(t.Name), "Count"},
-					MetricRequest{p.Leader, BeanTopicBytesInPerSec(t.Name), "Count"},
 				}...)
 			}
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -39,9 +39,9 @@ func FetchMetrics(ctx context.Context, metrics chan Metric, reqs []MetricRequest
 }
 
 func handleBrokerChanges(hps []zookeeper.HostPort) []MetricRequest {
-	reqs := make([]MetricRequest, len(hps)*4)
+	reqs := make([]MetricRequest, len(hps)*2)
 	for i, hp := range hps {
-		copy(reqs[i*4:], []MetricRequest{
+		copy(reqs[i*2:], []MetricRequest{
 			MetricRequest{hp.Id, BeanBrokerBytesInPerSec, "Count"},
 			MetricRequest{hp.Id, BeanBrokerBytesOutPerSec, "Count"},
 		})
@@ -52,7 +52,7 @@ func handleBrokerChanges(hps []zookeeper.HostPort) []MetricRequest {
 }
 
 func handleTopicChanges(topics []zookeeper.T) []MetricRequest {
-	reqs := make([]MetricRequest, 0, 5*len(topics))
+	reqs := make([]MetricRequest, 0, 3*len(topics))
 	for _, t := range topics {
 		topic, _ := FetchTopic(t.Name)
 		store.UpdateTopic(topic)


### PR DESCRIPTION
Reduce sample interval to 30 seconds
Don't query for ISR metrics
Don't query for BytesIn/BytesOut for topics

Before each mgmt instance made 4 reqs per broker and 5 reqs per partitions every 10 seconds
Now we do 2 reqs per broker and 3 reqs per partition every 30 seconds

Example: Cluster 3 nodes, 10 topics, 200 partitions (20 partitions per topic)
Before: `(4*3 + 5*200) * 3 = 3036` requests every 10 second
Now: `(2*3 + 3*200) * 3 = 1818` requests every 30 seconds

And if we only run it on first node the number of requests will be divided by 3. 